### PR TITLE
Fix 404 return link

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,7 +11,7 @@
   <main style="max-width:720px;margin:10vh auto;padding:1rem;text-align:center">
     <h1>Oops—page not found</h1>
     <p>The link may be outdated or the page moved.</p>
-    <p><a href="/">Return to the catalog</a></p>
+    <p><a href="./">Return to the catalog</a></p>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point the 404 page's "Return to the catalog" link to a relative target so it works when the site is hosted in a subdirectory

## Testing
- npm start (manually exercised the 404 page link)


------
https://chatgpt.com/codex/tasks/task_b_68d2bb4fed88832eb9b73f1e91740176