### PR TITLE
Use CSV export URLs for catalog feeds

### DIFF
--- a/scripts/catalog.js
+++ b/scripts/catalog.js
@@ -1,6 +1,6 @@
 // Published-to-web CSVs for Products & Variants
-const PRODUCTS_CSV = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRU7hseo3Sa3Y5oTSb5fIjItVIC8JKW0lJdRFK4bCpxQJHfz9nTQjSXrh2Bhkx5J5gG69PO4IRUYIg0/pubhtml?gid=653601520&single=true&output=csv";
-const VARIANTS_CSV = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRU7hseo3Sa3Y5oTSb5fIjItVIC8JKW0lJdRFK4bCpxQJHfz9nTQjSXrh2Bhkx5J5gG69PO4IRUYIg0/pubhtml?gid=140795318&single=true&output=csv";
+const PRODUCTS_CSV = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRU7hseo3Sa3Y5oTSb5fIjItVIC8JKW0lJdRFK4bCpxQJHfz9nTQjSXrh2Bhkx5J5gG69PO4IRUYIg0/pub?gid=653601520&single=true&output=csv";
+const VARIANTS_CSV = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRU7hseo3Sa3Y5oTSb5fIjItVIC8JKW0lJdRFK4bCpxQJHfz9nTQjSXrh2Bhkx5J5gG69PO4IRUYIg0/pub?gid=140795318&single=true&output=csv";
 
 async function fetchCSV(url){
   const res = await fetch(url,{cache:'no-store'});


### PR DESCRIPTION
## Summary
- update the catalog product and variant CSV endpoints to use the Google Sheets CSV export path

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_b_68d2c0057cf4832e909b7fadcd7e3cd5