### PR TITLE
Ensure showroom cards render inside grid container

### DIFF
--- a/scripts/showroom.js
+++ b/scripts/showroom.js
@@ -62,6 +62,7 @@
 
   const state = {
     cardsEl: null,
+    cardsGridEl: null,
     countEl: null,
     detailEl: null,
     titleEl: null,
@@ -191,9 +192,28 @@
     state.previewLink = previewLink;
   }
 
+  function ensureCardsGrid(){
+    if(!state.cardsEl) return false;
+
+    if(state.cardsEl.classList.contains('card-grid')){
+      state.cardsGridEl = state.cardsEl;
+      return true;
+    }
+
+    const existing = state.cardsEl.querySelector('.card-grid');
+    if(existing){
+      state.cardsGridEl = existing;
+      return true;
+    }
+
+    state.cardsEl.classList.add('card-grid');
+    state.cardsGridEl = state.cardsEl;
+    return true;
+  }
+
   function renderCards(products){
-    if(!state.cardsEl) return;
-    state.cardsEl.innerHTML = '';
+    if(!state.cardsGridEl) return;
+    state.cardsGridEl.innerHTML = '';
     products.forEach(product => {
       const card = document.createElement('a');
       card.className = 'card';
@@ -236,7 +256,7 @@
         }
       });
 
-      state.cardsEl.appendChild(card);
+      state.cardsGridEl.appendChild(card);
     });
 
     if(state.countEl){
@@ -482,6 +502,11 @@
     state.detailEl = document.getElementById('detail');
     if(!state.cardsEl || !state.detailEl){
       console.warn('Showroom markup is missing required containers.');
+      return;
+    }
+
+    if(!ensureCardsGrid()){
+      console.warn('Showroom cards container is missing a grid wrapper.');
       return;
     }
 


### PR DESCRIPTION
## Summary
- ensure the showroom catalog finds or assigns a `.card-grid` container when initializing
- render product cards into the dedicated grid element so preview pages retain existing layout styling

## Testing
- npm start (manual preview of http://127.0.0.1:4173/preview-showroom.html)


------
https://chatgpt.com/codex/tasks/task_b_68d2d8857abc832e849e330945c9de3e