### PR TITLE
Increase catalog thumbnail height

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -47,8 +47,13 @@ a:hover{text-decoration:underline}
 }
 .card-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fill,minmax(260px,1fr))}
 .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);box-shadow:0 1px 2px rgba(0,0,0,.06);display:flex;flex-direction:column;overflow:hidden;color:inherit;text-decoration:none}
-.card .card-thumb{aspect-ratio:4/3;background:#fafafa;display:flex;align-items:center;justify-content:center}
-.card .card-thumb img{width:100%;height:100%;object-fit:cover}
+.card .card-thumb{aspect-ratio:3/4;background:#fafafa;display:flex;align-items:center;justify-content:center}
+.card .card-thumb img{
+  max-height:100%;
+  max-width:100%;
+  width:auto;
+  height:auto;
+}
 .card .card-meta{padding:12px 14px;display:grid;gap:8px}
 .card .card-title{font-family:Montserrat,system-ui;font-weight:700}
 .card .card-price{font-family:Montserrat,system-ui;font-weight:700}


### PR DESCRIPTION
## Summary
- increase catalog card thumbnail containers to a taller 3:4 ratio so imagery fills more vertical space
- allow product images to scale within the taller frame via max-dimension constraints that preserve their original proportions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d368cb9330832ea6ef2ad2dc13325b